### PR TITLE
fix: Set use_texture_alpha

### DIFF
--- a/doors_chest.lua
+++ b/doors_chest.lua
@@ -161,6 +161,7 @@ function register_door(name, def)
 			type = "fixed",
 			fixed = def.selection_box_bottom
 		},
+		use_texture_alpha = def.use_texture_alpha,
 		groups = def.groups,
 
 		after_dig_node = function(pos, oldnode, oldmetadata, digger)
@@ -198,6 +199,7 @@ function register_door(name, def)
 			type = "fixed",
 			fixed = def.selection_box_top
 		},
+		use_texture_alpha = def.use_texture_alpha,
 		groups = def.groups,
 
 		after_dig_node = function(pos, oldnode, oldmetadata, digger)
@@ -235,6 +237,7 @@ function register_door(name, def)
 			type = "fixed",
 			fixed = def.selection_box_bottom
 		},
+		use_texture_alpha = def.use_texture_alpha,
 		groups = def.groups,
 
 		after_dig_node = function(pos, oldnode, oldmetadata, digger)
@@ -272,6 +275,7 @@ function register_door(name, def)
 			type = "fixed",
 			fixed = def.selection_box_top
 		},
+		use_texture_alpha = def.use_texture_alpha,
 		groups = def.groups,
 
 		after_dig_node = function(pos, oldnode, oldmetadata, digger)
@@ -303,6 +307,7 @@ local name = "protector:door_wood"
 register_door(name, {
 	description = S("Protected Wooden Door"),
 	inventory_image = "doors_wood.png^protector_logo.png",
+	use_texture_alpha = "clip",
 	groups = {
 		snappy = 1, choppy = 2, oddly_breakable_by_hand = 2,
 		unbreakable = 1, --door = 1
@@ -345,6 +350,7 @@ name = "protector:door_steel"
 register_door(name, {
 	description = S("Protected Steel Door"),
 	inventory_image = "doors_steel.png^protector_logo.png",
+	use_texture_alpha = "clip",
 	groups = {
 		snappy = 1, bendy = 2, cracky = 1,
 		level = 2, unbreakable = 1, -- door = 1
@@ -448,6 +454,7 @@ register_trapdoor("protector:trapdoor", {
 	wield_image = "doors_trapdoor.png^protector_logo.png",
 	tile_front = "doors_trapdoor.png^protector_logo.png",
 	tile_side = "doors_trapdoor_side.png",
+	use_texture_alpha = "clip",
 	groups = {
 		snappy = 1, choppy = 2, oddly_breakable_by_hand = 2,
 		unbreakable = 1, --door = 1
@@ -487,6 +494,7 @@ register_trapdoor("protector:trapdoor_steel", {
 	wield_image = "doors_trapdoor_steel.png^protector_logo.png",
 	tile_front = "doors_trapdoor_steel.png^protector_logo.png",
 	tile_side = "doors_trapdoor_steel_side.png",
+	use_texture_alpha = "clip",
 	groups = {
 		snappy = 1, bendy = 2, cracky = 1, melty = 2, level = 2,
 		unbreakable = 1, --door = 1

--- a/init.lua
+++ b/init.lua
@@ -508,6 +508,7 @@ minetest.register_node("protector:protect2", {
 	wield_image = "protector_logo.png",
 	inventory_image = "protector_logo.png",
 	sounds = default.node_sound_stone_defaults(),
+	use_texture_alpha = "clip",
 	groups = {dig_immediate = 2, unbreakable = 1},
 	is_ground_content = false,
 	paramtype = "light",


### PR DESCRIPTION
After minetest commit [8461cce72a22ec5350f4d04626e021427c6853ec][1] (i.e. in minetest 5.9.0-dev) nodes will have use_texture_alpha unset by default. This causes some nodes to show as black/white instead of transparent. Setting use_texture_alpha explicitly fixes this.

[1]: https://github.com/minetest/minetest/pull/13929

Tested on 5.9.0-dev-2c44620e5 (Linux).

Before:
![screenshot_20240226_221009](https://github.com/mt-mods/protector/assets/2508427/0ba90323-1743-4ff3-8ba9-b35fd63c09f9)

After:
![screenshot_20240226_221127](https://github.com/mt-mods/protector/assets/2508427/424c03fd-aa3d-430a-a4b9-6b72cd796188)
