### PR TITLE
Fix player factions check

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -189,7 +189,7 @@ local protector_formspec = function(meta)
 		else
 			local player_factions = factions.get_player_factions(meta:get_string("owner"))
 
-			if player_factions ~= nil and #player_factions >= 1 then
+			if player_factions and #player_factions >= 1 then
 				checkbox_faction = true
 			end
 		end


### PR DESCRIPTION
There was a problem with this line of code on Eden Lost. If a player is not in any factions, `factions.get_player_factions` returns `false`. This would lead to the code trying to use the `#` operator on a boolean value, causing a crash any time somebody right-clicked on a protector block.

This code was probably written for an older version of the factions mod.